### PR TITLE
Create archives in order, and upload and delete directly after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,34 @@
 
 ## Description
 
-Repository Chain Archiver is a tool designed to efficiently archive the Sourcify repository. It also supports uploading the archives to an S3-compatible object storage.
+Repository Chain Archiver is a tool designed to efficiently archive the Sourcify repository. It also uploads the archives to an S3-compatible object storage.
 
 ```ts
-const repositoryChainsArchiver = new RepositoryChainsArchiver(
-  ["1"], // chainIds
-  "./repository", // repositoryPath
-  "./exports" // exportPath
-);
-await repositoryChainsArchiver.processChain();
-// exports
-// ├── full_match.1.2F.tar.gz
-// ├── partial_match.1.1D.tar.gz
-// └── partial_match.1.3D.tar.gz
-
-await repositoryChainsArchiver.uploadS3({
+const s3Config = {
   bucketName: process.env.S3_BUCKET,
   region: process.env.S3_REGION,
   accessKeyId: process.env.S3_ACCESS_KEY_ID,
   secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
   endpoint: process.env.S3_ENDPOINT,
-});
+};
+
+const repositoryChainsArchiver = new RepositoryChainsArchiver(
+  ["1"], // chainIds
+  "./repository", // repositoryPath
+  "./exports", // exportPath
+  s3Config
+);
+await repositoryChainsArchiver.processAndUpload();
+// exports
+// ├── full_match.1.2F.tar.gz
+// ├── partial_match.1.1D.tar.gz
+// └── partial_match.1.3D.tar.gz
 ```
 
-RepositoryChainArchiver will create a `tar.gz` file for each combination of `matchType`, `chain`, and `first_byte`. 
+RepositoryChainArchiver will create a `tar.gz` file for each combination of `matchType`, `chain`, and `first_byte`.
 
 E.g. `exports/full_match.1.2F.tar.gz` will contain all the full_match contracts for chain 1 starting with `0x2F`.
+
 ```
 exports/repository
 └── full_match

--- a/src/RepositoryChainsArchiver.ts
+++ b/src/RepositoryChainsArchiver.ts
@@ -121,7 +121,7 @@ export default class RepositoryChainsArchiver {
               const s3Key = `${backupName}/${archiveName}`;
               await this.uploadFile(localPath, s3Key);
               uploadedFiles.push({
-                path: s3Key,
+                path: `/${s3Key}`,
                 sizeInBytes: fs.statSync(localPath).size,
               });
 

--- a/src/RepositoryChainsArchiver.ts
+++ b/src/RepositoryChainsArchiver.ts
@@ -135,8 +135,8 @@ export default class RepositoryChainsArchiver {
           }
         }
       }
-      this.uploadManifest(backupName, uploadedFiles);
-      this.deleteOldBackups();
+      await this.uploadManifest(backupName, uploadedFiles);
+      await this.deleteOldBackups();
       console.log("Deleted old backups");
     } catch (error) {
       console.error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,17 +33,18 @@ if (!process.env.CHAINS) {
   chainsToArchive = process.env.CHAINS.split(",");
 }
 
-const repositoryChainsArchiver = new RepositoryChainsArchiver(
-  chainsToArchive,
-  "./repository",
-  "./exports"
-);
-await repositoryChainsArchiver.processChains();
-
-await repositoryChainsArchiver.uploadS3({
+const s3Config = {
   bucketName: process.env.S3_BUCKET,
   region: process.env.S3_REGION,
   accessKeyId: process.env.S3_ACCESS_KEY_ID,
   secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
   endpoint: process.env.S3_ENDPOINT,
-});
+};
+
+const repositoryChainsArchiver = new RepositoryChainsArchiver(
+  chainsToArchive,
+  "./repository",
+  "./exports",
+  s3Config
+);
+await repositoryChainsArchiver.processAndUpload();


### PR DESCRIPTION
The archive job was creating the zip files on the NFS in GCP. To reduce load on the NFS, we want to keep the archives in memory of Cloud Run (same approach as in the parquet export). For this, it is needed to create, upload and delete the archives in order.